### PR TITLE
Revert PR #309

### DIFF
--- a/bin/rbac-providers-azure
+++ b/bin/rbac-providers-azure
@@ -22,8 +22,8 @@ import sys
 TOP_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, TOP_DIR)
 
-from rbac.providers.azure.main import users
+from rbac.providers.azure.main import fetch_users
 
 if __name__ == "__main__":
-    users = users()
+    users = fetch_users()
     print(users)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,9 @@ services:
     environment:
       - CLIENT_ID=${CLIENT_ID}
       - CLIENT_SECRET=${CLIENT_SECRET}
+      - CLIENT_ASSERTION=${CLIENT_ASSERTION}
       - TENANT_ID=${TENANT_ID}
+      - AUTH_TYPE=${AUTH_TYPE}
     command: ./bin/rbac-providers-azure
 
   rbac-server:

--- a/rbac/providers/azure/aad_auth.py
+++ b/rbac/providers/azure/aad_auth.py
@@ -19,9 +19,11 @@ import datetime as dt
 
 CLIENT_ID = os.environ.get('CLIENT_ID')
 CLIENT_SECRET = os.environ.get('CLIENT_SECRET')
+CLIENT_ASSERTION = os.environ.get('CLIENT_ASSERTION')
 TENANT_ID = os.environ.get('TENANT_ID')
 AAD_AUTH_URL = 'https://login.microsoftonline.com/{}'.format(TENANT_ID)
 TOKEN_ENDPOINT = '/oauth2/v2.0/token'
+TENANT_ID = os.environ.get('TENANT_ID')
 
 
 class AadAuth:
@@ -33,14 +35,25 @@ class AadAuth:
     def __init__(self):
         """Initialize the class."""
 
-    def get_token(self):
-        """Get an access Token for Azure Active Directory Graph API."""
-        data = {'client_id': CLIENT_ID,
+
+    def get_token(self, AUTH_TYPE):
+        if AUTH_TYPE.upper() == 'SECRET':
+            data = {'client_id': CLIENT_ID,
                 'scope': 'https://graph.microsoft.com/.default',
                 'client_secret': CLIENT_SECRET,
                 'grant_type': 'client_credentials'}
+        elif AUTH_TYPE.upper() == 'CERT':
+            data = {'grant_type': 'client_credentials',
+                'client_id': CLIENT_ID,
+                'client_assertion_type': 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+                'client_assertion': CLIENT_ASSERTION,
+                'scope': 'https://graph.microsoft.com/.default'}
+        else:
+            print('Missing AUTH_TYPE environment variable. Aborting sync with Azure AD.')
+            return None
         response = requests.post(url=AAD_AUTH_URL + TOKEN_ENDPOINT, data=data)
         return response
+
 
     def _time_left(self):
         """Check for how much time is left on the token."""
@@ -51,10 +64,20 @@ class AadAuth:
                 return True
         return False
 
-    def check_token(self):
+
+    def check_token(self, AUTH_TYPE):
         """Check it Token exists and calls for and caches as global variable if it does not."""
         if self.graph_token is None or not self._time_left():
-            response = self.get_token()
-            self.token_creation_timestamp = dt.datetime.now()
-            self.graph_token = response.json()['access_token']
-        return {'Authorization': self.graph_token, 'Accept': 'application/json'}
+            response = self.get_token(AUTH_TYPE)
+            if response is None:
+                return None
+            else:
+                self.token_creation_timestamp = dt.datetime.now()
+                self.graph_token = response.json()['access_token']
+                if AUTH_TYPE.upper() == "SECRET":
+                    return {'Authorization': self.graph_token, 
+                            'Accept': 'application/json'}
+                elif AUTH_TYPE.upper() == 'CERT':
+                    return {'Authorization': self.graph_token, 
+                            'Accept': 'application/json', 
+                            'Host': 'graph.microsoft.com'}            

--- a/rbac/providers/azure/main.py
+++ b/rbac/providers/azure/main.py
@@ -14,21 +14,25 @@
 # ------------------------------------------------------------------------------
 
 import requests
+import os
 from rbac.providers.azure.aad_auth import AadAuth
 
 GRAPH_URL = 'https://graph.microsoft.com/v1.0/'
 AUTH = AadAuth()
+AUTH_TYPE = os.environ.get('AUTH_TYPE')
 
 
 def fetch_groups():
     """JSON payload for all Groups in Azure Active Directory."""
-    headers = AUTH.check_token()
-    groups_payload = requests.get(url=GRAPH_URL + 'groups', headers=headers)
-    return groups_payload.json()
+    headers = AUTH.check_token(AUTH_TYPE)
+    if headers is not None:
+        groups_payload = requests.get(url=GRAPH_URL + 'groups', headers=headers)
+        return groups_payload.json()
 
 
 def fetch_users():
     """JSON payload for all Users in Azure Active Directory."""
-    headers = AUTH.check_token()
-    users_payload = requests.get(url=GRAPH_URL + 'users', headers=headers)
-    return users_payload.json()
+    headers = AUTH.check_token(AUTH_TYPE)
+    if headers is not None:
+        users_payload = requests.get(url=GRAPH_URL + 'users', headers=headers)
+        return users_payload.json()


### PR DESCRIPTION
Revert PR #309 Use SSL cert for Azure OAuth2 token generation.
Adds support for both SSL cert authentication and client secret authentication
to Azure AD sync daemon. Toggle authentication mode using AUTH_TYPE environment
variable ('CERT' or 'SECRET')

Signed-off-by: jbobo <j.ned@bobonana.me>